### PR TITLE
Allow installing a pre-commit hook in git submodules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ pkg/*
 .bundle
 *.gem
 tmp/*
+*.swp
 rerun.txt

--- a/features/draconian.feature
+++ b/features/draconian.feature
@@ -1,7 +1,7 @@
 #!/usr/bin/env cucumber
 Feature: Draconian option
 Background:
-  Given a directory named ".git/hooks"
+  Given I successfully run "git init"
     And a file named "Rakefile" with:
     """
     require "../../lib/git_precommit"

--- a/features/local-hook-path.feature
+++ b/features/local-hook-path.feature
@@ -1,7 +1,7 @@
 #!/usr/bin/env cucumber
 Feature: Using repository local hook scripts
 Background:
-  Given a directory named ".git/hooks"
+  Given I successfully run "git init"
     And a file named "Rakefile" with:
     """
     require "../../lib/git_precommit"

--- a/features/pre-commit.feature
+++ b/features/pre-commit.feature
@@ -1,7 +1,7 @@
 #!/usr/bin/env cucumber
 Feature: Pre commit hook installation
 Background:
-  Given a directory named ".git/hooks"
+  Given I successfully run "git init"
     And a file named "Rakefile" with:
     """
     require "../../lib/git_precommit"

--- a/features/submodule-hook-path.feature
+++ b/features/submodule-hook-path.feature
@@ -1,0 +1,38 @@
+#!/usr/bin/env cucumber
+Feature: Using a submodule's local hook scripts
+Background:
+  Given I successfully run "git init"
+    And I successfully run "git submodule add https://github.com/octocat/spoon-knife subproject"
+    And I cd to "subproject"
+    And a file named "Rakefile" with:
+    """
+    require "../../../lib/git_precommit"
+    GitPrecommit::PrecommitTasks.new :path => "myhooks"
+
+    git_directory = `git rev-parse --git-dir`.strip
+    task :default => "#{git_directory}/hooks/pre-commit"
+    """
+    And a directory named "./myhooks"
+    And a file named "./myhooks/pre-commit" with:
+    """
+    #!/usr/bin/env sh
+    # My Hook
+    """
+
+Scenario: No pre-commit hook is installed
+  When I successfully run "rake"
+
+  Then the following files should exist:
+    | ../.git/modules/subproject/hooks/pre-commit |
+
+   And the file "../.git/modules/subproject/hooks/pre-commit" should contain "My Hook"
+
+Scenario: The pre-commit hook is modified
+  When I append to "../.git/modules/subproject/hooks/pre-commit" with:
+  """
+  echo "My new hook!"
+  """
+
+  And I successfully run "rake"
+
+  Then the file "../.git/modules/subproject/hooks/pre-commit" should not contain "echo"

--- a/lib/git-precommit/precommit_tasks.rb
+++ b/lib/git-precommit/precommit_tasks.rb
@@ -24,7 +24,7 @@ module GitPrecommit
     end
 
     def define()
-      pre_commit     = ".git/hooks/pre-commit"
+      pre_commit     = "#{git_dir}/hooks/pre-commit"
       pre_commit_src = "#{template_path}/pre-commit"
 
       task :overwrite
@@ -39,7 +39,7 @@ module GitPrecommit
       end
 
       desc "Install the git post-commit hook"
-      file ".git/hooks/post-commit" => "#{template_path}/post-commit" do |t|
+      file "#{git_dir}/hooks/post-commit" => "#{template_path}/post-commit" do |t|
         copy t.prerequisites.first, t.name
         chmod 0755, t.name
       end
@@ -49,8 +49,11 @@ module GitPrecommit
         task :precommit => pre_commit
 
         desc "Install the git post-commit hook"
-        task :postcommit => ".git/hooks/post-commit"
+        task :postcommit => "#{git_dir}/hooks/post-commit"
       end
+    end
+    def git_dir()
+      `git rev-parse --git-dir`.strip
     end
   end
 end


### PR DESCRIPTION
I hear it's all the rage these days.
The tests were reworked to actually create git repos and submodules, because the gem now assumes that you're in a valid git repository and that `git rev-parse --git-dir` returns something sane.

Might need a documentation change explaining how a Rakefile within a submodule can work (see submodule-hook-path.feature's Rakefile). 
